### PR TITLE
ci: bump setup-node version

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - run: npm i -fg corepack && corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with: { node-version: lts/*, cache: "pnpm" }
       - run: pnpm install
       - run: pnpm lint:fix

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - run: npm i -fg corepack && corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with: { node-version: lts/*, cache: "pnpm" }
       - run: pnpm install
       - run: pnpm run lint


### PR DESCRIPTION
Actually actions/setup-node has v5 now. I thought may be we can use the updated version.