### PR TITLE
chore(prettier): ignore markdown files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,3 @@
 pnpm-lock.yaml
-README.md
+*.md
 test/snapshots


### PR DESCRIPTION
Actually we have two markdown files here. README.md and CHANGELOG.md. We have ignored readme file only in prettier. That's why I've made this change. 