### PR TITLE
refactor: separate import types

### DIFF
--- a/src/render.ts
+++ b/src/render.ts
@@ -1,8 +1,5 @@
-import {
-  parse as parseCookies,
-  serialize as serializeCookie,
-  type CookieSerializeOptions,
-} from "cookie-es";
+import { parse as parseCookies, serialize as serializeCookie } from "cookie-es";
+import type { CookieSerializeOptions } from "cookie-es";
 import type { CompiledTemplate } from "./compiler.ts";
 import { FastResponse } from "srvx";
 


### PR DESCRIPTION
I have separated a import type. But in the index.ts file, we have exported things together. I think maybe that is ok. 